### PR TITLE
Make injection work with derived scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 				"scopeName": "source.injected.glsl",
 				"path": "./syntaxes/glsl-injected.language.json",
 				"injectTo": [
-					"text.html.derivative"
+					"text.html"
 				]
 			}
 		],

--- a/syntaxes/glsl-injected.language.json
+++ b/syntaxes/glsl-injected.language.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "GLSL",
-	"injectionSelector": "R:text.html.derivative",
+	"injectionSelector": "R:text.html",
 	"patterns": [
 		{
 			"begin": "(?<=<script.*?type=\"x-shader\/x-(vertex|fragment)\".*?>)",


### PR DESCRIPTION
At the moment, other extensions (such as [Jinja](https://github.com/wholroyd/vscode-jinja) and [Better Jinja](https://github.com/samuelcolvin/jinjahtml-vscode)) disable GLSL syntax highlighting, because they replace `text.html.derivative` with e.g. `text.html.jinja`.

This can be fixed by injecting the GLSL grammar into the top-level `text.html` scope, which is what I have done in this pull request.