### PR TITLE
Add support compound extensions

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -3,10 +3,19 @@ import { EOL } from 'os';
 export class Constants {
     public static readonly EXTENSION_NAME = 'webgl-glsl-editor';
     public static readonly GLSL = 'glsl';
+
+    public static readonly VERT_GLSL = 'vert.glsl';
+    public static readonly VS_GLSL = 'vs.glsl';
     public static readonly VERT = 'vert';
     public static readonly VS = 'vs';
+    public static readonly VERTEX_EXTS = [this.VERT_GLSL, this.VS_GLSL, this.VERT, this.VS];
+
+    public static readonly FRAG_GLSL = 'frag.glsl';
+    public static readonly FS_GLSL = 'fs.glsl';
     public static readonly FRAG = 'frag';
     public static readonly FS = 'fs';
+    public static readonly FRAGMENT_EXTS = [this.FRAG_GLSL, this.FS_GLSL, this.FRAG, this.FS];
+
     public static readonly FILE = 'file';
     public static readonly UNTITLED = 'untitled';
     public static readonly PREPROCESSED_GLSL = 'webgl-glsl-editor-preprocessed';

--- a/src/core/document-info.ts
+++ b/src/core/document-info.ts
@@ -61,14 +61,36 @@ export class DocumentInfo {
         return this.visitor;
     }
 
+    public getExtension(size = 1): string {
+        const fileName = this.uri.path.substring(this.uri.path.lastIndexOf('/') + 1);
+        return fileName.split(Constants.DOT).slice(-size).join(Constants.DOT);
+    }
+
+    public getStageName(): string {
+        const ext1 = this.getExtension();
+        const ext2 = this.getExtension(2);
+
+        if (Constants.VERTEX_EXTS.includes(ext1) || Constants.VERTEX_EXTS.includes(ext2)) {
+            return Constants.VERT;
+        }
+
+        if (Constants.FRAGMENT_EXTS.includes(ext1) || Constants.FRAGMENT_EXTS.includes(ext2)) {
+            return Constants.FRAG;
+        }
+
+        return Constants.EMPTY;
+    }
+
     public getShaderStage(): ShaderStage {
         return this.stage;
     }
 
     private setShaderStage(): void {
-        if (this.uri.path.endsWith(Constants.FS) || this.uri.path.endsWith(Constants.FRAG)) {
+        const stageName = this.getStageName();
+
+        if (stageName === Constants.FRAG) {
             this.stage = ShaderStage.FRAGMENT;
-        } else if (this.uri.path.endsWith(Constants.VS) || this.uri.path.endsWith(Constants.VERT)) {
+        } else if (stageName === Constants.VERT) {
             this.stage = ShaderStage.VERTEX;
         } else {
             this.stage = ShaderStage.DEFAULT;

--- a/src/providers/glsl-diagnostic-provider.ts
+++ b/src/providers/glsl-diagnostic-provider.ts
@@ -113,8 +113,7 @@ export class GlslDiagnosticProvider {
         this.document = document;
         this.di = GlslEditor.getDocumentInfo(this.document.uri);
         const platformName = this.getPlatformName();
-        const extension = this.getExtension(this.document.uri);
-        const stageName = this.getStageName(extension);
+        const stageName = this.di.getStageName();
         const validatorPath = `${GlslEditor.getContext().extensionPath}/res/bin/glslangValidator${platformName}`;
         this.executeGeneration(validatorPath, stageName);
     }
@@ -136,8 +135,7 @@ export class GlslDiagnosticProvider {
 
     private addErrors(): void {
         const platformName = this.getPlatformName();
-        const extension = this.getExtension(this.document.uri);
-        const stageName = this.getStageName(extension);
+        const stageName = this.di.getStageName();
         const validatorPath = `${GlslEditor.getContext().extensionPath}/res/bin/glslangValidator${platformName}`;
         this.executeValidation(validatorPath, stageName);
     }
@@ -226,22 +224,4 @@ export class GlslDiagnosticProvider {
             default: return Constants.EMPTY;
         }
     }
-
-    private getExtension(uri: Uri): string {
-        return uri.fsPath.substring(uri.fsPath.lastIndexOf(Constants.DOT) + 1);
-    }
-
-    private getStageName(extension: string): string {
-        switch (extension) {
-            case Constants.VERT:
-            case Constants.VS:
-                return Constants.VERT;
-            case Constants.FRAG:
-            case Constants.FS:
-                return Constants.FRAG;
-            default:
-                return Constants.EMPTY;
-        }
-    }
-
 }


### PR DESCRIPTION
In some workflows, changing the file extension is undesirable. This may break some build utilities and waste time fixing them. This PR adds support for compound extensions such as `*.vert.glsl` or `*.fs.glsl`.