### PR TITLE
Fix missing diagnostics on macOS by marking validator as executable

### DIFF
--- a/src/providers/glsl-diagnostic-provider.ts
+++ b/src/providers/glsl-diagnostic-provider.ts
@@ -24,7 +24,7 @@ export class GlslDiagnosticProvider {
         GlslEditor.processElements(document);
         this.di = GlslEditor.getDocumentInfo(document.uri);
         this.document = document;
-        this.markValidatorAsExecutable();
+        this.markMacValidatorAsExecutableIfNeeded();
     }
 
     public textChanged(document: TextDocument): void {
@@ -237,7 +237,9 @@ export class GlslDiagnosticProvider {
         return `${GlslEditor.getContext().extensionPath}/res/bin/glslangValidator${platformName}`;
     }
 
-    private markValidatorAsExecutable() {
+    private markMacValidatorAsExecutableIfNeeded() {
+        if(platform() !== 'darwin') return;
+
         const validatorPath = this.getValidatorPath();
         
         try {


### PR DESCRIPTION
This pull request is meant to fix a bug that prevents diagnostics from working on macOS (likely the one referenced by #34.)

In my testing, to fix this it's enough to mark the `glslangValidatorMac` binary as executable using `chmod +x [pathToValidator]`. This pull request adds a method, `markValidatorAsExecutable()`, to the `GlslDiagnosticProvider` class that runs during `GlslDiagnosticProvider.initialize()`.