### PR TITLE
Multi-level nested `#include` support (expansion + source-mapped diagnostics/navigation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,6 +301,39 @@
                         ],
                         "description": "The lines of the injected source code. Only works if Code Injection is enabled.",
                         "order": 24
+                    },
+                    "webgl-glsl-editor.includes.enabled": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Enables/disables experimental #include support (phased rollout).",
+                        "order": 25
+                    },
+                    "webgl-glsl-editor.includes.searchPaths": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "default": [],
+                        "description": "Additional folders to search for #include files (besides the including file’s folder).",
+                        "order": 26
+                    },
+                    "webgl-glsl-editor.includes.maxDepth": {
+                        "type": "number",
+                        "default": 32,
+                        "description": "Maximum nested #include depth.",
+                        "order": 27
+                    },
+                    "webgl-glsl-editor.includes.maxTotalBytes": {
+                        "type": "number",
+                        "default": 1048576,
+                        "description": "Maximum total expanded size (in bytes) across all nested includes.",
+                        "order": 28
+                    },
+                    "webgl-glsl-editor.includes.allowAngledIncludes": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Allow #include <...> form (in addition to #include \"...\").",
+                        "order": 29
                     }
                 }
             }

--- a/src/builtin/info/preprocessor.ts
+++ b/src/builtin/info/preprocessor.ts
@@ -1,5 +1,6 @@
 export const preprocessorDirectives: Array<Array<Array<string>>> = [
     [['version'], ['100', '300'], ['es']],
+    [['include']],
     [['define']],
     [['undef']],
     [['if']],

--- a/src/core/configurations.ts
+++ b/src/core/configurations.ts
@@ -1,4 +1,5 @@
-import { ConfigurationChangeEvent, workspace } from 'vscode';
+import { ConfigurationChangeEvent, Uri, workspace } from 'vscode';
+import { IncludeResolverOptions } from '../include/include-types';
 import { Constants } from './constants';
 import { GlslEditor } from './glsl-editor';
 
@@ -28,6 +29,12 @@ export class Configurations {
     private static readonly SPACES_INSIDE_BRACKETS = 'format.placeSpacesInsideBrackets';
     private static readonly FAVOR_FLOATING_SUFFIX = 'format.favorFloatingSuffix';
 
+    private static readonly INCLUDES_ENABLED = 'includes.enabled';
+    private static readonly INCLUDES_SEARCH_PATHS = 'includes.searchPaths';
+    private static readonly INCLUDES_MAX_DEPTH = 'includes.maxDepth';
+    private static readonly INCLUDES_MAX_TOTAL_BYTES = 'includes.maxTotalBytes';
+    private static readonly INCLUDES_ALLOW_ANGLED = 'includes.allowAngledIncludes';
+
     private diagnostics: boolean;
     private strictRename: boolean;
     private alwaysOpenOnlineDoc: boolean;
@@ -52,6 +59,12 @@ export class Configurations {
     private spaceBeforeOpeningBrackets: boolean;
     private spacesInsideBrackets: boolean;
     private favorFloatingSuffix: boolean;
+
+    private includesEnabled: boolean;
+    private includesSearchPaths: Array<string>;
+    private includesMaxDepth: number;
+    private includesMaxTotalBytes: number;
+    private includesAllowAngledIncludes: boolean;
 
     public constructor() {
         const config = workspace.getConfiguration(Constants.EXTENSION_NAME);
@@ -79,6 +92,12 @@ export class Configurations {
         this.spaceBeforeOpeningBrackets = config.get(Configurations.SPACE_BEFORE_OPENING_BRACKETS);
         this.spacesInsideBrackets = config.get(Configurations.SPACES_INSIDE_BRACKETS);
         this.favorFloatingSuffix = config.get(Configurations.FAVOR_FLOATING_SUFFIX);
+
+        this.includesEnabled = config.get(Configurations.INCLUDES_ENABLED);
+        this.includesSearchPaths = config.get(Configurations.INCLUDES_SEARCH_PATHS);
+        this.includesMaxDepth = config.get(Configurations.INCLUDES_MAX_DEPTH);
+        this.includesMaxTotalBytes = config.get(Configurations.INCLUDES_MAX_TOTAL_BYTES);
+        this.includesAllowAngledIncludes = config.get(Configurations.INCLUDES_ALLOW_ANGLED);
 
         workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
             const config = workspace.getConfiguration(Constants.EXTENSION_NAME);
@@ -161,6 +180,23 @@ export class Configurations {
                 this.spacesInsideBrackets = config.get(Configurations.SPACES_INSIDE_BRACKETS);
             } else if (e.affectsConfiguration(`${Constants.EXTENSION_NAME}.${Configurations.FAVOR_FLOATING_SUFFIX}`)) {
                 this.favorFloatingSuffix = config.get(Configurations.FAVOR_FLOATING_SUFFIX);
+            } else if (e.affectsConfiguration(`${Constants.EXTENSION_NAME}.${Configurations.INCLUDES_ENABLED}`)) {
+                this.includesEnabled = config.get(Configurations.INCLUDES_ENABLED);
+                GlslEditor.invalidateDocuments();
+            } else if (e.affectsConfiguration(`${Constants.EXTENSION_NAME}.${Configurations.INCLUDES_SEARCH_PATHS}`)) {
+                this.includesSearchPaths = config.get(Configurations.INCLUDES_SEARCH_PATHS);
+                GlslEditor.invalidateDocuments();
+            } else if (e.affectsConfiguration(`${Constants.EXTENSION_NAME}.${Configurations.INCLUDES_MAX_DEPTH}`)) {
+                this.includesMaxDepth = config.get(Configurations.INCLUDES_MAX_DEPTH);
+                GlslEditor.invalidateDocuments();
+            } else if (
+                e.affectsConfiguration(`${Constants.EXTENSION_NAME}.${Configurations.INCLUDES_MAX_TOTAL_BYTES}`)
+            ) {
+                this.includesMaxTotalBytes = config.get(Configurations.INCLUDES_MAX_TOTAL_BYTES);
+                GlslEditor.invalidateDocuments();
+            } else if (e.affectsConfiguration(`${Constants.EXTENSION_NAME}.${Configurations.INCLUDES_ALLOW_ANGLED}`)) {
+                this.includesAllowAngledIncludes = config.get(Configurations.INCLUDES_ALLOW_ANGLED);
+                GlslEditor.invalidateDocuments();
             }
         });
     }
@@ -259,5 +295,74 @@ export class Configurations {
 
     public getFavorFloatingSuffix(): boolean {
         return this.favorFloatingSuffix;
+    }
+
+    public getIncludesEnabled(): boolean {
+        return this.includesEnabled;
+    }
+
+    public getIncludesSearchPaths(): Array<string> {
+        return this.includesSearchPaths;
+    }
+
+    public getIncludesMaxDepth(): number {
+        return this.includesMaxDepth;
+    }
+
+    public getIncludesMaxTotalBytes(): number {
+        return this.includesMaxTotalBytes;
+    }
+
+    public getIncludesAllowAngledIncludes(): boolean {
+        return this.includesAllowAngledIncludes;
+    }
+
+    public getIncludeResolverOptions(): IncludeResolverOptions {
+        const folders = this.getIncludesSearchPaths() ?? [];
+        const searchPaths = folders.map((p) => this.toSearchPathUri(p)).filter((u): u is Uri => u != null);
+
+        return {
+            enabled: this.getIncludesEnabled() ?? false,
+            allowAngledIncludes: this.getIncludesAllowAngledIncludes() ?? false,
+            searchPaths,
+            maxDepth: this.getIncludesMaxDepth() ?? 32,
+            maxTotalBytes: this.getIncludesMaxTotalBytes() ?? 1024 * 1024,
+        };
+    }
+
+    private toSearchPathUri(value: string): Uri | null {
+        const p = (value ?? '').trim();
+        if (!p) {
+            return null;
+        }
+
+        // Accept explicit URIs: file://, vscode-remote://, etc.
+        if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(p)) {
+            try {
+                return Uri.parse(p);
+            } catch {
+                return null;
+            }
+        }
+
+        const isWindowsAbs = /^[a-zA-Z]:[\\/]/.test(p);
+        const isPosixAbs = p.startsWith('/');
+
+        // If relative, interpret relative to the first workspace folder.
+        if (!isWindowsAbs && !isPosixAbs) {
+            const root = workspace.workspaceFolders?.[0]?.uri;
+            if (!root) {
+                return null;
+            }
+            const segments = p.split(/[\\/]+/g).filter(Boolean);
+            return Uri.joinPath(root, ...segments);
+        }
+
+        // Absolute filesystem path (desktop extension only).
+        try {
+            return Uri.file(p);
+        } catch {
+            return null;
+        }
     }
 }

--- a/src/core/document-info.ts
+++ b/src/core/document-info.ts
@@ -3,6 +3,9 @@ import { Location, Position, Range, TextDocument, Uri } from 'vscode';
 import { AntlrGlslLexer } from '../_generated/AntlrGlslLexer';
 import { AntlrGlslParser } from '../_generated/AntlrGlslParser';
 import { Builtin } from '../builtin/builtin';
+import { ExpandedDocument, ExpandedSource } from '../include/expanded-document';
+import { ExpandedDocumentCache } from '../include/expanded-document-cache';
+import { SourceMap } from '../include/source-map';
 import { FunctionCall } from '../scope/function/function-call';
 import { FunctionDeclaration } from '../scope/function/function-declaration';
 import { Interval } from '../scope/interval';
@@ -31,6 +34,8 @@ export class DocumentInfo {
     private invalid = false;
 
     private visitor: GlslVisitor;
+
+    private expanded: ExpandedDocument | null = null;
 
     private version = 100;
     private stage: ShaderStage;
@@ -128,9 +133,10 @@ export class DocumentInfo {
     }
 
     public getTokenAt(position: Position): Token {
+        const offset = this.positionToOffset(position);
         for (const token of this.getTokens()) {
-            const range = this.intervalToRange(new Interval(token.startIndex, token.stopIndex + 1, this));
-            if (range.contains(position)) {
+            const interval = new Interval(token.startIndex, token.stopIndex + 1, this);
+            if (offset >= interval.startIndex && offset < interval.stopIndex) {
                 return token;
             }
         }
@@ -151,18 +157,75 @@ export class DocumentInfo {
 
     private processDocument(document: TextDocument): void {
         this.document = document;
+        this.expanded = ExpandedDocumentCache.get(document);
+        this.applyInjectionToExpandedIfNeeded();
         this.lexer = this.createLexer();
         this.parser = this.createParser();
+    }
+
+    private applyInjectionToExpandedIfNeeded(): void {
+        if (!this.expanded) {
+            return;
+        }
+
+        // Reset; code injection is opt-in and not used for preprocessed docs.
+        this.injectionLineCount = 0;
+        this.injectionOffset = 0;
+
+        if (!GlslEditor.CONFIGURATIONS.getCodeInjection() || this.uri.scheme === Constants.PREPROCESSED_GLSL) {
+            return;
+        }
+
+        const injectionSource = GlslEditor.CONFIGURATIONS.getCodeInjectionSource();
+        const prelude = injectionSource.join(Constants.NEW_LINE) + Constants.NEW_LINE;
+        this.injectionLineCount = injectionSource.length;
+        this.injectionOffset = prelude.length;
+
+        if (!prelude) {
+            return;
+        }
+
+        // Compose a per-document expanded snapshot that also contains the injected prelude.
+        // The injected prelude is marked as generated so it does not map to any real source file.
+        const sm = new SourceMap();
+        sm.appendGenerated(prelude);
+        sm.appendFrom(this.expanded.sourceMap);
+        this.expanded = {
+            ...this.expanded,
+            text: prelude + this.expanded.text,
+            sourceMap: sm,
+        };
     }
 
     private createLexer(): AntlrGlslLexer {
         //The ANTLRInputStream class is deprecated, however as far as I know this is the only way the TypeScript version of ANTLR accepts UTF-16 strings.
         //The CharStreams.fromString method only accepts UTF-8 and other methods of the CharStreams class are not implemented in TypeScript.
-        const charStream = new ANTLRInputStream(this.getText());
+        const charStream = new ANTLRInputStream(this.getParseText());
         const lexer = new AntlrGlslLexer(charStream);
         this.tokens = lexer.getAllTokens();
         lexer.reset();
         return lexer;
+    }
+
+    private getParseText(): string {
+        // In include mode, we parse the expanded text snapshot if available.
+        if (this.expanded && GlslEditor.CONFIGURATIONS.getIncludeResolverOptions().enabled) {
+            return this.expanded.text;
+        }
+        return this.getText();
+    }
+
+    /**
+     * Text used for compiler diagnostics.
+     *
+     * When includes are enabled and an expanded snapshot is available, diagnostics should compile
+     * the same expanded text we parse, so line numbers can be mapped back via the SourceMap.
+     */
+    public getCompilerText(): string {
+        if (this.expanded && GlslEditor.CONFIGURATIONS.getIncludeResolverOptions().enabled) {
+            return this.expanded.text;
+        }
+        return this.getText();
     }
 
     public getText(): string {
@@ -203,25 +266,60 @@ export class DocumentInfo {
     }
 
     public intervalToLocation(interval: Interval): Location {
-        const range = this.intervalToRange(interval);
-        return new Location(this.document.uri, range);
+        const mapped = this.intervalToMappedRange(interval);
+        if (!mapped) {
+            return null;
+        }
+        return new Location(mapped.uri, mapped.range);
     }
 
     public intervalToRange(interval: Interval): Range {
+        return this.intervalToMappedRange(interval)?.range ?? null;
+    }
+
+    private intervalToMappedRange(interval: Interval): { uri: Uri; range: Range } | null {
         if (!interval) {
             return null;
         }
-        const start = this.offsetToPosition(interval.startIndex);
-        const stop = this.offsetToPosition(interval.stopIndex);
-        return new Range(start, stop);
+
+        if (!this.hasSourceMap()) {
+            const start = this.offsetToPosition(interval.startIndex);
+            const stop = this.offsetToPosition(interval.stopIndex);
+            if (!start || !stop) {
+                return null;
+            }
+            return { uri: this.document.uri, range: new Range(start, stop) };
+        }
+
+        const startMapped = this.mapVirtualOffsetToPosition(interval.startIndex);
+        const stopMapped = this.mapVirtualOffsetToPosition(interval.stopIndex);
+        if (!startMapped || !stopMapped) {
+            return null;
+        }
+
+        // If an interval somehow crosses files, keep it anchored to the start file.
+        const uri = startMapped.uri;
+        const stop = stopMapped.uri.toString(true) === uri.toString(true) ? stopMapped.position : startMapped.position;
+        return { uri, range: new Range(startMapped.position, stop) };
     }
 
     public offsetToPosition(offset: number): Position {
-        return this.document.positionAt(offset);
+        if (!this.hasSourceMap()) {
+            return this.document.positionAt(offset);
+        }
+
+        const mapped = this.mapVirtualOffsetToPosition(offset);
+        return mapped?.position ?? null;
     }
 
     public positionToOffset(position: Position): number {
-        return this.document.offsetAt(position);
+        if (!this.hasSourceMap()) {
+            return this.document.offsetAt(position);
+        }
+
+        const sourceOffset = this.document.offsetAt(position);
+        const v = this.expanded.sourceMap.mapSourceOffset(this.document.uri, sourceOffset);
+        return v ?? sourceOffset;
     }
 
     public lineAndCharacterToRange(line: number, character: number): Range {
@@ -230,7 +328,133 @@ export class DocumentInfo {
     }
 
     public getTextInInterval(interval: Interval): string {
-        return this.document.getText(this.intervalToRange(interval));
+        if (!interval) {
+            return Constants.EMPTY;
+        }
+        if (!this.hasSourceMap()) {
+            return this.document.getText(this.intervalToRange(interval));
+        }
+
+        const start = this.expanded.sourceMap.mapVirtualOffset(interval.startIndex);
+        const stop = this.expanded.sourceMap.mapVirtualOffset(interval.stopIndex);
+        if (!start || !stop) {
+            return Constants.EMPTY;
+        }
+        if (start.uri.toString(true) !== stop.uri.toString(true)) {
+            return Constants.EMPTY;
+        }
+        const src = this.getExpandedSource(start.uri);
+        if (!src) {
+            return Constants.EMPTY;
+        }
+        return src.text.substring(start.offset, stop.offset);
+    }
+
+    public hasSourceMap(): boolean {
+        return this.expanded != null;
+    }
+
+    public getIncludeSourceUris(): Array<Uri> {
+        if (!this.expanded) {
+            return [this.document.uri];
+        }
+        const result: Array<Uri> = [];
+        for (const s of this.expanded.sources.values()) {
+            result.push(s.uri);
+        }
+        return result;
+    }
+
+    public getLineRangeAtUri(uri: Uri, line0: number): Range | null {
+        if (!uri) {
+            return null;
+        }
+
+        if (uri.toString(true) === this.document.uri.toString(true)) {
+            if (line0 < 0 || line0 >= this.document.lineCount) {
+                return null;
+            }
+            return this.document.lineAt(line0).range;
+        }
+
+        const src = this.getExpandedSource(uri);
+        if (!src) {
+            return null;
+        }
+
+        const starts = src.lineStarts;
+        if (line0 < 0 || line0 >= starts.length) {
+            return null;
+        }
+        const startOffset = starts[line0];
+        let endOffset = line0 + 1 < starts.length ? starts[line0 + 1] : src.text.length;
+
+        // Trim a single trailing newline (and optional preceding \r) so the range matches VS Code's line range.
+        if (endOffset > startOffset) {
+            const last = src.text.charCodeAt(endOffset - 1);
+            if (last === 10 /* \n */) {
+                endOffset--;
+                if (endOffset > startOffset && src.text.charCodeAt(endOffset - 1) === 13 /* \r */) {
+                    endOffset--;
+                }
+            }
+        }
+
+        const endChar = Math.max(0, endOffset - startOffset);
+        return new Range(new Position(line0, 0), new Position(line0, endChar));
+    }
+
+    public isVirtualOffsetInjected(offset: number): boolean {
+        if (!this.expanded) {
+            return offset < 0;
+        }
+        return this.expanded.sourceMap.isGeneratedVirtualOffset(offset);
+    }
+
+    private mapVirtualOffsetToPosition(offset: number): { uri: Uri; position: Position } | null {
+        if (!this.expanded) {
+            return { uri: this.document.uri, position: this.document.positionAt(offset) };
+        }
+
+        const loc = this.expanded.sourceMap.mapVirtualOffset(offset);
+        if (!loc) {
+            return null;
+        }
+
+        if (loc.uri.toString(true) === this.document.uri.toString(true)) {
+            return { uri: this.document.uri, position: this.document.positionAt(loc.offset) };
+        }
+
+        const src = this.getExpandedSource(loc.uri);
+        if (!src) {
+            return null;
+        }
+
+        return { uri: src.uri, position: this.positionAtInSource(src, loc.offset) };
+    }
+
+    private getExpandedSource(uri: Uri): ExpandedSource | null {
+        const k = uri.toString(true);
+        return this.expanded?.sources.get(k) ?? null;
+    }
+
+    private positionAtInSource(source: ExpandedSource, offset: number): Position {
+        const starts = source.lineStarts;
+        let lo = 0;
+        let hi = starts.length - 1;
+        while (lo <= hi) {
+            const mid = (lo + hi) >>> 1;
+            const s = starts[mid];
+            const n = mid + 1 < starts.length ? starts[mid + 1] : source.text.length + 1;
+            if (offset < s) {
+                hi = mid - 1;
+            } else if (offset >= n) {
+                lo = mid + 1;
+            } else {
+                return new Position(mid, Math.max(0, offset - s));
+            }
+        }
+        return new Position(0, 0);
     }
 
     //
@@ -283,25 +507,48 @@ export class DocumentInfo {
             | 'functionPrototypes'
             | 'functionDefinitions'
     ): VariableDeclaration | VariableUsage | TypeDeclaration | TypeUsage | FunctionCall | FunctionDeclaration {
-        let scope: Scope = this.rootScope;
-        while (scope) {
-            for (const element of scope[type]) {
-                if (
-                    element.nameInterval &&
-                    !element.nameInterval.isInjected() &&
-                    this.intervalToRange(element.nameInterval)?.contains(position)
-                ) {
-                    return element;
-                }
+        const offset = this.positionToOffset(position);
+        return this.findElementAtOffset(this.rootScope, type, offset);
+    }
+
+    private findElementAtOffset(
+        scope: Scope,
+        type:
+            | 'variableDeclarations'
+            | 'variableUsages'
+            | 'typeDeclarations'
+            | 'typeUsages'
+            | 'functionCalls'
+            | 'functionPrototypes'
+            | 'functionDefinitions',
+        offset: number
+    ): VariableDeclaration | VariableUsage | TypeDeclaration | TypeUsage | FunctionCall | FunctionDeclaration {
+        // Prefer the most nested scope first.
+        for (const child of scope.children) {
+            const found = this.findElementAtOffset(child, type, offset);
+            if (found) {
+                return found;
             }
-            scope = this.getChildScope(scope, position);
         }
+
+        for (const element of scope[type]) {
+            if (
+                element.nameInterval &&
+                !element.nameInterval.isInjected() &&
+                offset >= element.nameInterval.startIndex &&
+                offset < element.nameInterval.stopIndex
+            ) {
+                return element;
+            }
+        }
+
         return null;
     }
 
     private getChildScope(scope: Scope, position: Position): Scope {
+        const offset = this.positionToOffset(position);
         for (const childScope of scope.children) {
-            if (this.intervalToRange(childScope.interval)?.contains(position)) {
+            if (offset >= childScope.interval.startIndex && offset < childScope.interval.stopIndex) {
                 return childScope;
             }
         }
@@ -334,9 +581,10 @@ export class DocumentInfo {
     }
 
     private getCaseDepthAt(position: Position): number {
+        const offset = this.positionToOffset(position);
         let depth = 0;
         for (const cr of this.regions.caseStatementsRegions) {
-            if (this.intervalToRange(cr)?.contains(position)) {
+            if (offset >= cr.startIndex && offset < cr.stopIndex) {
                 depth++;
             }
         }

--- a/src/core/glsl-editor.ts
+++ b/src/core/glsl-editor.ts
@@ -1,5 +1,6 @@
 import { DiagnosticCollection, ExtensionContext, TextDocument, Uri, languages } from 'vscode';
 import { HostDependent } from '../host-dependent';
+import { ExpandedDocumentCache } from '../include/expanded-document-cache';
 import { Configurations } from './configurations';
 import { Constants } from './constants';
 import { DocumentInfo } from './document-info';
@@ -20,6 +21,7 @@ export class GlslEditor {
     }
 
     public static processElements(document: TextDocument): void {
+        ExpandedDocumentCache.schedule(document);
         const di = this.getDocumentInfo(document.uri);
         di.processElements(document);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
-import { commands, DocumentSelector, ExtensionContext, languages } from 'vscode';
+import { commands, DocumentSelector, ExtensionContext, languages, workspace } from 'vscode';
 import { Constants } from './core/constants';
+import { ExpandedDocumentCache } from './include/expanded-document-cache';
 import { GlslCallHierarchyProvider } from './providers/glsl-call-hierarchy-provider';
 import { GlslCommandProvider } from './providers/glsl-command-provider';
 import { GlslCompletionProvider } from './providers/glsl-completion-provider';
@@ -60,6 +61,22 @@ export function addSharedCommands(context: ExtensionContext): void {
 }
 
 export function addSharedFeatures(context: ExtensionContext): void {
+    // include cache invalidation (phased rollout)
+    context.subscriptions.push(
+        workspace.onDidChangeTextDocument((e) => {
+            if (e.document.languageId === Constants.GLSL) {
+                ExpandedDocumentCache.invalidate(e.document.uri);
+            }
+        })
+    );
+    context.subscriptions.push(
+        workspace.onDidCloseTextDocument((e) => {
+            if (e.languageId === Constants.GLSL) {
+                ExpandedDocumentCache.invalidate(e.uri);
+            }
+        })
+    );
+
     //syntax highlighting
     context.subscriptions.push(
         languages.registerDocumentSemanticTokensProvider(

--- a/src/include/expanded-document-cache.ts
+++ b/src/include/expanded-document-cache.ts
@@ -11,6 +11,7 @@ interface CacheEntry {
     version: number;
     expanded: ExpandedDocument | null;
     inFlight: Promise<void> | null;
+    deps: Set<string>; // includes + self (uriKey strings)
 }
 
 /**
@@ -20,9 +21,37 @@ interface CacheEntry {
  */
 export class ExpandedDocumentCache {
     private static entries = new Map<string, CacheEntry>();
+    private static reverseDeps = new Map<string, Set<string>>(); // included -> roots
 
     public static clear(): void {
         this.entries.clear();
+        this.reverseDeps.clear();
+    }
+
+    public static invalidate(uri: Uri): void {
+        const k = key(uri);
+        // Direct entry
+        this.entries.delete(k);
+
+        // Invalidate the document info as well so providers re-process.
+        GlslEditor.getDocumentInfo(uri).invalidate();
+
+        // Any roots that depend on this uri
+        const roots = this.reverseDeps.get(k);
+        if (roots) {
+            for (const rootKey of roots) {
+                this.entries.delete(rootKey);
+
+                // Also invalidate the dependent root DocumentInfo.
+                try {
+                    GlslEditor.getDocumentInfo(Uri.parse(rootKey)).invalidate();
+                } catch {
+                    // ignore parse failures
+                }
+            }
+        }
+
+        // Note: reverseDeps is intentionally kept; it will be refreshed on next expansion.
     }
 
     public static get(document: TextDocument): ExpandedDocument | null {
@@ -57,15 +86,55 @@ export class ExpandedDocumentCache {
             version: document.version,
             expanded: null,
             inFlight: null,
+            deps: new Set<string>(),
         };
         this.entries.set(k, entry);
 
         entry.inFlight = (async () => {
             try {
                 entry.expanded = await IncludeExpander.expand(document.uri, document.getText(), options);
+                this.updateDependencyIndex(k, entry.expanded);
+
+                // Trigger re-parse on next provider invocation with the now-available snapshot.
+                GlslEditor.getDocumentInfo(document.uri).invalidate();
             } finally {
                 entry.inFlight = null;
             }
         })();
+    }
+
+    private static updateDependencyIndex(rootKey: string, expanded: ExpandedDocument): void {
+        const entry = this.entries.get(rootKey);
+        if (!entry) {
+            return;
+        }
+
+        // Remove previous reverse deps
+        for (const depKey of entry.deps) {
+            const set = this.reverseDeps.get(depKey);
+            if (set) {
+                set.delete(rootKey);
+                if (set.size === 0) {
+                    this.reverseDeps.delete(depKey);
+                }
+            }
+        }
+
+        // Compute new deps from expanded sources.
+        const deps = new Set<string>();
+        for (const k of expanded.sources.keys()) {
+            deps.add(k);
+        }
+        deps.add(rootKey);
+        entry.deps = deps;
+
+        for (const depKey of deps) {
+            let set = this.reverseDeps.get(depKey);
+            if (!set) {
+                set = new Set<string>();
+                this.reverseDeps.set(depKey, set);
+            }
+            set.add(rootKey);
+        }
     }
 }

--- a/src/include/expanded-document-cache.ts
+++ b/src/include/expanded-document-cache.ts
@@ -1,0 +1,71 @@
+import { TextDocument, Uri } from 'vscode';
+import { GlslEditor } from '../core/glsl-editor';
+import { ExpandedDocument } from './expanded-document';
+import { IncludeExpander } from './include-expander';
+
+function key(uri: Uri): string {
+    return uri.toString(true);
+}
+
+interface CacheEntry {
+    version: number;
+    expanded: ExpandedDocument | null;
+    inFlight: Promise<void> | null;
+}
+
+/**
+ * Phase 3: asynchronous expansion cache.
+ *
+ * Providers remain synchronous by consuming the most recently expanded snapshot.
+ */
+export class ExpandedDocumentCache {
+    private static entries = new Map<string, CacheEntry>();
+
+    public static clear(): void {
+        this.entries.clear();
+    }
+
+    public static get(document: TextDocument): ExpandedDocument | null {
+        const e = this.entries.get(key(document.uri));
+        if (!e) {
+            return null;
+        }
+        if (e.version !== document.version) {
+            return null;
+        }
+        return e.expanded;
+    }
+
+    public static schedule(document: TextDocument): void {
+        const options = GlslEditor.CONFIGURATIONS.getIncludeResolverOptions();
+        if (!options.enabled) {
+            return;
+        }
+
+        const k = key(document.uri);
+        const existing = this.entries.get(k);
+        if (existing && existing.version === document.version) {
+            if (existing.expanded) {
+                return;
+            }
+            if (existing.inFlight) {
+                return;
+            }
+        }
+
+        const entry: CacheEntry = {
+            version: document.version,
+            expanded: null,
+            inFlight: null,
+        };
+        this.entries.set(k, entry);
+
+        entry.inFlight = (async () => {
+            try {
+                entry.expanded = await IncludeExpander.expand(document.uri, document.getText(), options);
+            } finally {
+                entry.inFlight = null;
+            }
+        })();
+    }
+}

--- a/src/include/expanded-document.ts
+++ b/src/include/expanded-document.ts
@@ -2,10 +2,17 @@ import { Uri } from 'vscode';
 import { IncludeGraph, IncludeResolutionError } from './include-types';
 import { SourceMap } from './source-map';
 
+export interface ExpandedSource {
+    uri: Uri;
+    text: string;
+    lineStarts: Array<number>;
+}
+
 export interface ExpandedDocument {
     root: Uri;
     text: string;
     sourceMap: SourceMap;
+    sources: Map<string, ExpandedSource>; // key: uri.toString(true)
     graph: IncludeGraph;
     errors: Array<IncludeResolutionError>;
 }

--- a/src/include/expanded-document.ts
+++ b/src/include/expanded-document.ts
@@ -1,0 +1,11 @@
+import { Uri } from 'vscode';
+import { IncludeGraph, IncludeResolutionError } from './include-types';
+import { SourceMap } from './source-map';
+
+export interface ExpandedDocument {
+    root: Uri;
+    text: string;
+    sourceMap: SourceMap;
+    graph: IncludeGraph;
+    errors: Array<IncludeResolutionError>;
+}

--- a/src/include/include-expander.ts
+++ b/src/include/include-expander.ts
@@ -1,0 +1,121 @@
+import { Uri, workspace } from 'vscode';
+import { ExpandedDocument } from './expanded-document';
+import { IncludeResolver } from './include-resolver';
+import { IncludeResolutionError, IncludeResolverOptions, ResolvedInclude } from './include-types';
+import { SourceMap } from './source-map';
+
+async function readTextFile(uri: Uri): Promise<string> {
+    const data = await workspace.fs.readFile(uri);
+    return new TextDecoder('utf-8').decode(data);
+}
+
+function computeLineStartOffsets(text: string): Array<number> {
+    const starts = [0];
+    for (let i = 0; i < text.length; i++) {
+        const c = text.charCodeAt(i);
+        if (c === 10 /* \n */) {
+            starts.push(i + 1);
+        }
+    }
+    return starts;
+}
+
+function getLineSliceOffsets(
+    text: string,
+    lineStartOffsets: Array<number>,
+    line: number
+): { start: number; end: number } {
+    const start = lineStartOffsets[line] ?? text.length;
+    const nextStart = lineStartOffsets[line + 1];
+    const end = nextStart != null ? nextStart : text.length;
+    return { start, end };
+}
+
+export class IncludeExpander {
+    /**
+     * Phase 2: produce expanded text + source map.
+     * Later phases will feed this expanded text into the ANTLR pipeline.
+     */
+    public static async expand(
+        root: Uri,
+        rootText: string,
+        options: IncludeResolverOptions
+    ): Promise<ExpandedDocument> {
+        const graph = await IncludeResolver.buildGraph(root, rootText, options);
+        // Use the same backing array so expansion-time errors aren't dropped.
+        const errors: Array<IncludeResolutionError> = graph.errors;
+
+        if (!options.enabled) {
+            const sm = new SourceMap();
+            sm.appendSource(root, 0, rootText.length);
+            return { root, text: rootText, sourceMap: sm, graph, errors };
+        }
+
+        const visited = new Set<string>();
+        const { text, sourceMap } = await this.expandFile(root, rootText, errors, options, visited);
+        return { root, text, sourceMap, graph, errors };
+    }
+
+    private static async expandFile(
+        uri: Uri,
+        text: string,
+        errors: Array<IncludeResolutionError>,
+        options: IncludeResolverOptions,
+        visited: Set<string>
+    ): Promise<{ text: string; sourceMap: SourceMap }> {
+        const key = uri.toString(true);
+        if (visited.has(key)) {
+            // cycle already reported by graph builder; keep original text
+            const sm = new SourceMap();
+            sm.appendSource(uri, 0, text.length);
+            return { text, sourceMap: sm };
+        }
+        visited.add(key);
+
+        const directives = IncludeResolver.scanDirectives(text);
+        const lineToInclude = new Map<number, ResolvedInclude>();
+        for (const d of directives) {
+            const resolved = await IncludeResolver.tryResolveInclude(uri, d, options, errors);
+            if (resolved) {
+                lineToInclude.set(d.line, resolved);
+            }
+        }
+
+        const lineStarts = computeLineStartOffsets(text);
+        const lineCount = lineStarts.length;
+
+        let out = '';
+        const sm = new SourceMap();
+
+        for (let line = 0; line < lineCount; line++) {
+            const resolved = lineToInclude.get(line);
+            const { start, end } = getLineSliceOffsets(text, lineStarts, line);
+
+            if (!resolved) {
+                out += text.slice(start, end);
+                sm.appendSource(uri, start, end);
+                continue;
+            }
+
+            // Replace the include directive line with included file content.
+            try {
+                const includedText = await readTextFile(resolved.to);
+                const expandedIncluded = await this.expandFile(resolved.to, includedText, errors, options, visited);
+                out += expandedIncluded.text;
+                sm.appendFrom(expandedIncluded.sourceMap);
+            } catch (e) {
+                errors.push({
+                    from: uri,
+                    directive: resolved.directive,
+                    message: `Failed to expand include: ${String(e)}`,
+                });
+                // Fall back to keeping original line as-is.
+                out += text.slice(start, end);
+                sm.appendSource(uri, start, end);
+            }
+        }
+
+        visited.delete(key);
+        return { text: out, sourceMap: sm };
+    }
+}

--- a/src/include/include-expander.ts
+++ b/src/include/include-expander.ts
@@ -1,13 +1,9 @@
-import { Uri, workspace } from 'vscode';
+import { Uri } from 'vscode';
 import { ExpandedDocument, ExpandedSource } from './expanded-document';
 import { IncludeResolver } from './include-resolver';
 import { IncludeResolutionError, IncludeResolverOptions, ResolvedInclude } from './include-types';
 import { SourceMap } from './source-map';
-
-async function readTextFile(uri: Uri): Promise<string> {
-    const data = await workspace.fs.readFile(uri);
-    return new TextDecoder('utf-8').decode(data);
-}
+import { WorkspaceText } from './workspace-text';
 
 function computeLineStartOffsets(text: string): Array<number> {
     const starts = [0];
@@ -114,8 +110,15 @@ export class IncludeExpander {
             out += text.slice(start, end);
             sm.appendSource(uri, start, end);
 
+            // NOTE: If the include directive is the last line without a trailing newline,
+            // ensure the included content begins on the next line.
+            if (end === text.length && end > start && text.charCodeAt(end - 1) !== 10 /* \n */) {
+                out += '\n';
+                sm.appendGenerated('\n');
+            }
+
             try {
-                const includedText = await readTextFile(resolved.to);
+                const includedText = await WorkspaceText.readText(resolved.to);
                 const expandedIncluded = await this.expandFile(
                     resolved.to,
                     includedText,

--- a/src/include/include-expander.ts
+++ b/src/include/include-expander.ts
@@ -1,5 +1,5 @@
 import { Uri, workspace } from 'vscode';
-import { ExpandedDocument } from './expanded-document';
+import { ExpandedDocument, ExpandedSource } from './expanded-document';
 import { IncludeResolver } from './include-resolver';
 import { IncludeResolutionError, IncludeResolverOptions, ResolvedInclude } from './include-types';
 import { SourceMap } from './source-map';
@@ -18,6 +18,10 @@ function computeLineStartOffsets(text: string): Array<number> {
         }
     }
     return starts;
+}
+
+function uriKey(uri: Uri): string {
+    return uri.toString(true);
 }
 
 function getLineSliceOffsets(
@@ -45,15 +49,18 @@ export class IncludeExpander {
         // Use the same backing array so expansion-time errors aren't dropped.
         const errors: Array<IncludeResolutionError> = graph.errors;
 
+        const sources = new Map<string, ExpandedSource>();
+        sources.set(uriKey(root), { uri: root, text: rootText, lineStarts: computeLineStartOffsets(rootText) });
+
         if (!options.enabled) {
             const sm = new SourceMap();
             sm.appendSource(root, 0, rootText.length);
-            return { root, text: rootText, sourceMap: sm, graph, errors };
+            return { root, text: rootText, sourceMap: sm, sources, graph, errors };
         }
 
         const visited = new Set<string>();
-        const { text, sourceMap } = await this.expandFile(root, rootText, errors, options, visited);
-        return { root, text, sourceMap, graph, errors };
+        const { text, sourceMap } = await this.expandFile(root, rootText, errors, options, visited, sources);
+        return { root, text, sourceMap, sources, graph, errors };
     }
 
     private static async expandFile(
@@ -61,9 +68,10 @@ export class IncludeExpander {
         text: string,
         errors: Array<IncludeResolutionError>,
         options: IncludeResolverOptions,
-        visited: Set<string>
+        visited: Set<string>,
+        sources: Map<string, ExpandedSource>
     ): Promise<{ text: string; sourceMap: SourceMap }> {
-        const key = uri.toString(true);
+        const key = uriKey(uri);
         if (visited.has(key)) {
             // cycle already reported by graph builder; keep original text
             const sm = new SourceMap();
@@ -71,6 +79,10 @@ export class IncludeExpander {
             return { text, sourceMap: sm };
         }
         visited.add(key);
+
+        if (!sources.has(key)) {
+            sources.set(key, { uri, text, lineStarts: computeLineStartOffsets(text) });
+        }
 
         const directives = IncludeResolver.scanDirectives(text);
         const lineToInclude = new Map<number, ResolvedInclude>();
@@ -97,10 +109,21 @@ export class IncludeExpander {
                 continue;
             }
 
-            // Replace the include directive line with included file content.
+            // Preserve the include directive line for stable source mapping,
+            // then inline the included content after it.
+            out += text.slice(start, end);
+            sm.appendSource(uri, start, end);
+
             try {
                 const includedText = await readTextFile(resolved.to);
-                const expandedIncluded = await this.expandFile(resolved.to, includedText, errors, options, visited);
+                const expandedIncluded = await this.expandFile(
+                    resolved.to,
+                    includedText,
+                    errors,
+                    options,
+                    visited,
+                    sources
+                );
                 out += expandedIncluded.text;
                 sm.appendFrom(expandedIncluded.sourceMap);
             } catch (e) {
@@ -109,9 +132,7 @@ export class IncludeExpander {
                     directive: resolved.directive,
                     message: `Failed to expand include: ${String(e)}`,
                 });
-                // Fall back to keeping original line as-is.
-                out += text.slice(start, end);
-                sm.appendSource(uri, start, end);
+                // Keep going; the directive line is already emitted.
             }
         }
 

--- a/src/include/include-resolver.ts
+++ b/src/include/include-resolver.ts
@@ -7,6 +7,7 @@ import {
     IncludeResolverOptions,
     ResolvedInclude,
 } from './include-types';
+import { WorkspaceText } from './workspace-text';
 
 // Supports: #include "path" and #include <path>, with optional trailing //... or /* ... */ comments.
 const INCLUDE_RE = /^\s*#\s*include\s+(?:"([^"]+)"|<([^>]+)>)\s*(?:(?:\/\/.*)|(?:\/\*.*\*\/\s*))?$/;
@@ -20,8 +21,7 @@ function splitIncludePath(p: string): Array<string> {
 }
 
 async function readTextFile(uri: Uri): Promise<string> {
-    const data = await workspace.fs.readFile(uri);
-    return new TextDecoder('utf-8').decode(data);
+    return await WorkspaceText.readText(uri);
 }
 
 export class IncludeResolver {

--- a/src/include/include-resolver.ts
+++ b/src/include/include-resolver.ts
@@ -1,0 +1,174 @@
+import { Uri, workspace } from 'vscode';
+import {
+    IncludeDirective,
+    IncludeGraph,
+    IncludeGraphNode,
+    IncludeResolutionError,
+    IncludeResolverOptions,
+    ResolvedInclude,
+} from './include-types';
+
+// Supports: #include "path" and #include <path>, with optional trailing //... or /* ... */ comments.
+const INCLUDE_RE = /^\s*#\s*include\s+(?:"([^"]+)"|<([^>]+)>)\s*(?:(?:\/\/.*)|(?:\/\*.*\*\/\s*))?$/;
+
+function uriKey(uri: Uri): string {
+    return uri.toString(true);
+}
+
+function splitIncludePath(p: string): Array<string> {
+    return p.split(/[\\/]+/g).filter(Boolean);
+}
+
+async function readTextFile(uri: Uri): Promise<string> {
+    const data = await workspace.fs.readFile(uri);
+    return new TextDecoder('utf-8').decode(data);
+}
+
+export class IncludeResolver {
+    public static scanDirectives(text: string): Array<IncludeDirective> {
+        const directives: Array<IncludeDirective> = [];
+        const lines = text.split(/\r?\n/g);
+        for (let i = 0; i < lines.length; i++) {
+            const lineText = lines[i];
+            const m = INCLUDE_RE.exec(lineText);
+            if (!m) {
+                continue;
+            }
+            const quoted = m[1];
+            const angled = m[2];
+            directives.push({
+                line: i,
+                raw: lineText,
+                path: (quoted ?? angled).trim(),
+                kind: quoted ? 'quoted' : 'angled',
+            });
+        }
+        return directives;
+    }
+
+    public static async buildGraph(
+        root: Uri,
+        rootText: string,
+        options: IncludeResolverOptions
+    ): Promise<IncludeGraph> {
+        const graph: IncludeGraph = {
+            root,
+            nodes: new Map<string, IncludeGraphNode>(),
+            errors: [],
+        };
+
+        if (!options.enabled) {
+            graph.nodes.set(uriKey(root), { uri: root, includes: [] });
+            return graph;
+        }
+
+        const totalBytes = { value: rootText.length };
+        await this.visit(root, rootText, graph, options, [], totalBytes);
+        return graph;
+    }
+
+    private static async visit(
+        uri: Uri,
+        text: string,
+        graph: IncludeGraph,
+        options: IncludeResolverOptions,
+        stack: Array<string>,
+        totalBytes: { value: number }
+    ): Promise<void> {
+        const key = uriKey(uri);
+        if (graph.nodes.has(key)) {
+            return;
+        }
+
+        // stack length corresponds to include nesting depth from the root.
+        if (stack.length > options.maxDepth) {
+            graph.errors.push({ from: uri, message: `Max include depth (${options.maxDepth}) exceeded.` });
+            graph.nodes.set(key, { uri, includes: [] });
+            return;
+        }
+
+        if (totalBytes.value > options.maxTotalBytes) {
+            graph.errors.push({ from: uri, message: `Max include size (${options.maxTotalBytes} bytes) exceeded.` });
+            graph.nodes.set(key, { uri, includes: [] });
+            return;
+        }
+
+        const directives = this.scanDirectives(text);
+        const includes: Array<ResolvedInclude> = [];
+        graph.nodes.set(key, { uri, includes });
+
+        for (const directive of directives) {
+            if (directive.kind === 'angled' && !options.allowAngledIncludes) {
+                graph.errors.push({
+                    from: uri,
+                    directive,
+                    message: 'Angled includes (<...>) are disabled by configuration.',
+                });
+                continue;
+            }
+
+            const resolved = await this.resolveInclude(uri, directive, options, graph.errors);
+            if (!resolved) {
+                continue;
+            }
+
+            const toKey = uriKey(resolved.to);
+            if (stack.includes(toKey)) {
+                graph.errors.push({ from: uri, directive, message: 'Include cycle detected.' });
+                continue;
+            }
+
+            includes.push(resolved);
+
+            try {
+                const includedText = await readTextFile(resolved.to);
+                totalBytes.value += includedText.length;
+                await this.visit(resolved.to, includedText, graph, options, [...stack, toKey], totalBytes);
+            } catch (e) {
+                graph.errors.push({
+                    from: uri,
+                    directive,
+                    message: `Failed to read include '${directive.path}': ${String(e)}`,
+                });
+            }
+        }
+    }
+
+    private static async resolveInclude(
+        from: Uri,
+        directive: IncludeDirective,
+        options: IncludeResolverOptions,
+        errors: Array<IncludeResolutionError>
+    ): Promise<ResolvedInclude | null> {
+        if (!directive.path) {
+            errors.push({ from, directive, message: 'Empty include path.' });
+            return null;
+        }
+
+        const candidates: Array<Uri> = [];
+
+        // 1) relative to current file
+        if (directive.kind === 'quoted') {
+            const rel = splitIncludePath(directive.path);
+            candidates.push(Uri.joinPath(from, '..', ...rel));
+        }
+
+        // 2) search paths
+        const segments = splitIncludePath(directive.path);
+        for (const base of options.searchPaths) {
+            candidates.push(Uri.joinPath(base, ...segments));
+        }
+
+        for (const candidate of candidates) {
+            try {
+                await workspace.fs.stat(candidate);
+                return { from, to: candidate, directive };
+            } catch {
+                // try next
+            }
+        }
+
+        errors.push({ from, directive, message: `Include not found: ${directive.path}` });
+        return null;
+    }
+}

--- a/src/include/include-resolver.ts
+++ b/src/include/include-resolver.ts
@@ -67,6 +67,15 @@ export class IncludeResolver {
         return graph;
     }
 
+    public static async tryResolveInclude(
+        from: Uri,
+        directive: IncludeDirective,
+        options: IncludeResolverOptions,
+        errors: Array<IncludeResolutionError>
+    ): Promise<ResolvedInclude | null> {
+        return await this.resolveInclude(from, directive, options, errors);
+    }
+
     private static async visit(
         uri: Uri,
         text: string,

--- a/src/include/include-types.ts
+++ b/src/include/include-types.ts
@@ -1,0 +1,39 @@
+import { Uri } from 'vscode';
+
+export interface IncludeDirective {
+    line: number; // 0-based
+    raw: string;
+    path: string;
+    kind: 'quoted' | 'angled';
+}
+
+export interface ResolvedInclude {
+    from: Uri;
+    to: Uri;
+    directive: IncludeDirective;
+}
+
+export interface IncludeResolutionError {
+    from: Uri;
+    directive?: IncludeDirective;
+    message: string;
+}
+
+export interface IncludeResolverOptions {
+    enabled: boolean;
+    allowAngledIncludes: boolean;
+    searchPaths: Array<Uri>;
+    maxDepth: number;
+    maxTotalBytes: number;
+}
+
+export interface IncludeGraphNode {
+    uri: Uri;
+    includes: Array<ResolvedInclude>;
+}
+
+export interface IncludeGraph {
+    root: Uri;
+    nodes: Map<string, IncludeGraphNode>; // key: uri.toString(true)
+    errors: Array<IncludeResolutionError>;
+}

--- a/src/include/source-map.ts
+++ b/src/include/source-map.ts
@@ -1,0 +1,128 @@
+import { Uri } from 'vscode';
+
+export interface SourceLocation {
+    uri: Uri;
+    offset: number;
+}
+
+export interface SourceMapSegment {
+    /** Virtual offset start (inclusive) */
+    virtualStart: number;
+    /** Virtual offset end (exclusive) */
+    virtualEnd: number;
+
+    /** Source file for this segment; null means generated text */
+    sourceUri: Uri | null;
+    /** Source offset start (inclusive) */
+    sourceStart: number;
+    /** Source offset end (exclusive) */
+    sourceEnd: number;
+}
+
+export class SourceMap {
+    private readonly segments: Array<SourceMapSegment> = [];
+
+    public getSegments(): ReadonlyArray<SourceMapSegment> {
+        return this.segments;
+    }
+
+    public appendGenerated(text: string): void {
+        if (!text) {
+            return;
+        }
+        const start = this.virtualLength();
+        this.segments.push({
+            virtualStart: start,
+            virtualEnd: start + text.length,
+            sourceUri: null,
+            sourceStart: 0,
+            sourceEnd: 0,
+        });
+    }
+
+    public appendSource(uri: Uri, sourceStart: number, sourceEnd: number): void {
+        if (sourceEnd <= sourceStart) {
+            return;
+        }
+        const start = this.virtualLength();
+        const len = sourceEnd - sourceStart;
+        this.segments.push({
+            virtualStart: start,
+            virtualEnd: start + len,
+            sourceUri: uri,
+            sourceStart,
+            sourceEnd,
+        });
+    }
+
+    public appendFrom(other: SourceMap): void {
+        const base = this.virtualLength();
+        for (const s of other.getSegments()) {
+            this.segments.push({
+                virtualStart: s.virtualStart + base,
+                virtualEnd: s.virtualEnd + base,
+                sourceUri: s.sourceUri,
+                sourceStart: s.sourceStart,
+                sourceEnd: s.sourceEnd,
+            });
+        }
+    }
+
+    public virtualLength(): number {
+        if (!this.segments.length) {
+            return 0;
+        }
+        return this.segments[this.segments.length - 1].virtualEnd;
+    }
+
+    public mapVirtualOffset(offset: number): SourceLocation | null {
+        for (const s of this.segments) {
+            if (offset >= s.virtualStart && offset < s.virtualEnd) {
+                if (!s.sourceUri) {
+                    return null;
+                }
+                const delta = offset - s.virtualStart;
+                return { uri: s.sourceUri, offset: s.sourceStart + delta };
+            }
+
+            // Allow mapping of exclusive end offsets (offset === virtualEnd) to a stable
+            // source location at the end of the corresponding segment.
+            if (offset === s.virtualEnd) {
+                if (!s.sourceUri) {
+                    return null;
+                }
+                return { uri: s.sourceUri, offset: s.sourceEnd };
+            }
+        }
+        return null;
+    }
+
+    public mapSourceOffset(sourceUri: Uri, sourceOffset: number): number | null {
+        for (const s of this.segments) {
+            if (!s.sourceUri) {
+                continue;
+            }
+            if (s.sourceUri.toString(true) !== sourceUri.toString(true)) {
+                continue;
+            }
+            if (sourceOffset >= s.sourceStart && sourceOffset < s.sourceEnd) {
+                return s.virtualStart + (sourceOffset - s.sourceStart);
+            }
+
+            // Allow mapping of exclusive end offsets (sourceOffset === sourceEnd).
+            if (sourceOffset === s.sourceEnd) {
+                return s.virtualEnd;
+            }
+        }
+        return null;
+    }
+
+    public isGeneratedVirtualOffset(offset: number): boolean {
+        for (const s of this.segments) {
+            if (offset >= s.virtualStart && offset < s.virtualEnd) {
+                return s.sourceUri == null;
+            }
+        }
+        return false;
+    }
+}

--- a/src/include/workspace-text.ts
+++ b/src/include/workspace-text.ts
@@ -1,0 +1,26 @@
+import { TextDocument, Uri, workspace } from 'vscode';
+
+function uriKey(uri: Uri): string {
+    return uri.toString(true);
+}
+
+export class WorkspaceText {
+    public static getOpenTextDocument(uri: Uri): TextDocument | null {
+        const k = uriKey(uri);
+        for (const d of workspace.textDocuments) {
+            if (uriKey(d.uri) === k) {
+                return d;
+            }
+        }
+        return null;
+    }
+
+    public static async readText(uri: Uri): Promise<string> {
+        const open = this.getOpenTextDocument(uri);
+        if (open) {
+            return open.getText();
+        }
+        const data = await workspace.fs.readFile(uri);
+        return new TextDecoder('utf-8').decode(data);
+    }
+}

--- a/src/processor/expression-processor.ts
+++ b/src/processor/expression-processor.ts
@@ -461,13 +461,26 @@ export class ExpressionProcessor {
         nameInterval: Interval,
         parameters: Array<ExpressionResult>
     ): LogicalFunction {
-        if (parameters.some((param) => !param || !param.type)) {
-            return null;
+        const hasUnknownTypes = parameters.some((param) => !param || !param.type);
+        if (!hasUnknownTypes) {
+            const lf = FunctionProcessor.searchFunction(name, nameInterval, parameters, this.scope, this.di);
+            if (lf) {
+                return lf;
+            }
+        } else {
+            // Best-effort: allow navigation even when expression typing fails.
+            const lf = FunctionProcessor.searchFunctionLoosely(
+                name,
+                nameInterval,
+                parameters.length,
+                this.scope,
+                this.di
+            );
+            if (lf) {
+                return lf;
+            }
         }
-        const lf = FunctionProcessor.searchFunction(name, nameInterval, parameters, this.scope, this.di);
-        if (lf) {
-            return lf;
-        }
+
         const array = Helper.getArraySizeFromArraySubscript(
             this.ctx.function_call().array_subscript(),
             this.scope,

--- a/src/processor/function-processor.ts
+++ b/src/processor/function-processor.ts
@@ -44,6 +44,63 @@ export class FunctionProcessor {
         return di.builtin.functions.find((lf) => this.areFunctionsMatch(lf, name, nameInterval, parameters)) ?? null;
     }
 
+    /**
+     * Best-effort function lookup when parameter types cannot be inferred.
+     * Used to keep navigation features (e.g. Go to Definition) working.
+     */
+    public static searchFunctionLoosely(
+        name: string,
+        nameInterval: Interval,
+        parameterCount: number,
+        scope: Scope,
+        di: DocumentInfo
+    ): LogicalFunction {
+        while (scope) {
+            const lf = this.findLooseMatchInScope(scope, name, nameInterval, parameterCount);
+            if (lf) {
+                return lf;
+            } else if (this.anyTypeOrVariable(name, nameInterval, scope)) {
+                return null;
+            }
+            scope = scope.parent;
+        }
+        return this.findLooseMatchInList(di.builtin.functions, name, nameInterval, parameterCount);
+    }
+
+    private static findLooseMatchInScope(
+        scope: Scope,
+        name: string,
+        nameInterval: Interval,
+        parameterCount: number
+    ): LogicalFunction {
+        return this.findLooseMatchInList(scope.functions, name, nameInterval, parameterCount);
+    }
+
+    private static findLooseMatchInList(
+        list: Array<LogicalFunction>,
+        name: string,
+        nameInterval: Interval,
+        parameterCount: number
+    ): LogicalFunction {
+        let best: LogicalFunction = null;
+        let bestStop = -1;
+        for (const lf of list) {
+            const fd = lf.getDeclaration();
+            if (
+                fd.name === name &&
+                fd.parameters.length === parameterCount &&
+                Helper.isALowerThanB(fd.interval, nameInterval)
+            ) {
+                const stop = fd.interval?.stopIndex ?? -1;
+                if (stop > bestStop) {
+                    bestStop = stop;
+                    best = lf;
+                }
+            }
+        }
+        return best;
+    }
+
     private static areFunctionsMatch(
         lf: LogicalFunction,
         name: string,

--- a/src/providers/glsl-diagnostic-provider.ts
+++ b/src/providers/glsl-diagnostic-provider.ts
@@ -8,6 +8,7 @@ import { getCompilerPath } from '../extension-desktop';
 import { Element } from '../scope/element';
 import { FunctionDeclaration } from '../scope/function/function-declaration';
 import { LogicalFunction } from '../scope/function/logical-function';
+import { Interval } from '../scope/interval';
 import { Scope } from '../scope/scope';
 import { TypeDeclaration } from '../scope/type/type-declaration';
 import { VariableDeclaration } from '../scope/variable/variable-declaration';
@@ -15,15 +16,50 @@ import { GlslTextProvider } from './glsl-text-provider';
 
 export class GlslDiagnosticProvider {
     private static newestLintIds = new Map<Uri, number>();
+    private static previouslyPublishedUrisByRoot = new Map<string, Set<string>>();
 
     private di: DocumentInfo;
-    private diagnostics = new Array<Diagnostic>();
+    private diagnosticsByUri = new Map<string, { uri: Uri; diagnostics: Array<Diagnostic> }>();
     private document: TextDocument;
+
+    private includeDiagnosticsMode = false;
+    private compilerTextLineStarts: Array<number> = [];
+
+    private static uriKey(uri: Uri): string {
+        return uri.toString(true);
+    }
+
+    private clearDiagnostics(): void {
+        this.diagnosticsByUri.clear();
+    }
+
+    private pushDiagnostic(uri: Uri, diagnostic: Diagnostic): void {
+        const k = GlslDiagnosticProvider.uriKey(uri);
+        let entry = this.diagnosticsByUri.get(k);
+        if (!entry) {
+            entry = { uri, diagnostics: [] };
+            this.diagnosticsByUri.set(k, entry);
+        }
+        entry.diagnostics.push(diagnostic);
+    }
+
+    private computeLineStarts(text: string): Array<number> {
+        const starts = [0];
+        for (let i = 0; i < text.length; i++) {
+            if (text.charCodeAt(i) === 10 /* \n */) {
+                starts.push(i + 1);
+            }
+        }
+        return starts;
+    }
 
     private initialize(document: TextDocument): void {
         GlslEditor.processElements(document);
         this.di = GlslEditor.getDocumentInfo(document.uri);
         this.document = document;
+        this.includeDiagnosticsMode =
+            this.di.hasSourceMap() && GlslEditor.CONFIGURATIONS.getIncludeResolverOptions().enabled;
+        this.clearDiagnostics();
     }
 
     public textChanged(document: TextDocument): void {
@@ -96,10 +132,13 @@ export class GlslDiagnosticProvider {
 
     private addUnusedHint(element: Element, message: string): void {
         if (element.nameInterval && !element.nameInterval.isInjected()) {
-            const range = this.di.intervalToRange(element.nameInterval);
-            const d = new Diagnostic(range, message, DiagnosticSeverity.Hint);
+            const loc = this.di.intervalToLocation(element.nameInterval);
+            if (!loc) {
+                return;
+            }
+            const d = new Diagnostic(loc.range, message, DiagnosticSeverity.Hint);
             d.tags = [DiagnosticTag.Unnecessary];
-            this.diagnostics.push(d);
+            this.pushDiagnostic(loc.uri, d);
         }
     }
 
@@ -157,11 +196,43 @@ export class GlslDiagnosticProvider {
         });
         result.stdout.on('close', () => {
             if (lintId === this.getCurrentLintId() && !this.document.isClosed) {
-                GlslEditor.getDiagnosticCollection().set(this.document.uri, this.diagnostics);
+                this.publishDiagnostics();
             }
         });
         this.di.setInjectionError(false);
         this.provideInput(result);
+    }
+
+    private publishDiagnostics(): void {
+        const collection = GlslEditor.getDiagnosticCollection();
+
+        const rootKey = GlslDiagnosticProvider.uriKey(this.document.uri);
+
+        const currentUris = new Set<string>();
+        if (this.includeDiagnosticsMode) {
+            for (const uri of this.di.getIncludeSourceUris()) {
+                currentUris.add(GlslDiagnosticProvider.uriKey(uri));
+            }
+        } else {
+            currentUris.add(rootKey);
+        }
+
+        // Clear any diagnostics previously published for this root that no longer apply.
+        const prev = GlslDiagnosticProvider.previouslyPublishedUrisByRoot.get(rootKey);
+        if (prev) {
+            for (const k of prev) {
+                if (!currentUris.has(k)) {
+                    collection.set(Uri.parse(k), []);
+                }
+            }
+        }
+
+        for (const k of currentUris) {
+            const entry = this.diagnosticsByUri.get(k);
+            collection.set(entry?.uri ?? Uri.parse(k), entry?.diagnostics ?? []);
+        }
+
+        GlslDiagnosticProvider.previouslyPublishedUrisByRoot.set(rootKey, currentUris);
     }
 
     private increaseLintId(): number {
@@ -197,33 +268,53 @@ export class GlslDiagnosticProvider {
 
     private addDiagnostic(row: string): void {
         if (row.startsWith('ERROR: 0:')) {
-            const t1 = row.substring(9);
-            const i = t1.indexOf(Constants.COLON);
-            const line = +t1.substring(0, i) - this.di.getInjectionLineCount();
-            if (line > 0) {
-                const error = row.substring(9 + i + 2);
-                this.diagnostics.push(
-                    new Diagnostic(this.document.lineAt(line - 1).range, error, DiagnosticSeverity.Error)
-                );
-            } else {
-                this.di.setInjectionError(true);
-            }
+            this.addCompilerDiagnostic(row, 9, DiagnosticSeverity.Error);
         } else if (row.startsWith('WARNING: 0:')) {
-            const t1 = row.substring(11);
-            const i = t1.indexOf(Constants.COLON);
-            const line = +t1.substring(0, i) - this.di.getInjectionLineCount();
-            if (line > 0) {
-                const error = row.substring(11 + i + 2);
-                this.diagnostics.push(
-                    new Diagnostic(this.document.lineAt(line - 1).range, error, DiagnosticSeverity.Warning)
-                );
+            this.addCompilerDiagnostic(row, 11, DiagnosticSeverity.Warning);
+        }
+    }
+
+    private addCompilerDiagnostic(row: string, headerLen: number, severity: DiagnosticSeverity): void {
+        const t1 = row.substring(headerLen);
+        const i = t1.indexOf(Constants.COLON);
+        const lineRaw = +t1.substring(0, i);
+        const message = row.substring(headerLen + i + 2);
+
+        if (this.includeDiagnosticsMode) {
+            const virtualLine0 = lineRaw - 1;
+            if (virtualLine0 < 0 || virtualLine0 >= this.compilerTextLineStarts.length) {
+                return;
             }
+
+            const vOffset = this.compilerTextLineStarts[virtualLine0];
+            const loc = this.di.intervalToLocation(new Interval(vOffset, vOffset + 1, this.di));
+            if (!loc) {
+                // Typically means this diagnostic points to generated/injected prelude.
+                this.di.setInjectionError(true);
+                return;
+            }
+
+            const lineRange = this.di.getLineRangeAtUri(loc.uri, loc.range.start.line) ?? loc.range;
+            this.pushDiagnostic(loc.uri, new Diagnostic(lineRange, message, severity));
+            return;
+        }
+
+        // Legacy mode: subtract injection line count and publish only to the root.
+        const line = lineRaw - this.di.getInjectionLineCount();
+        if (line > 0) {
+            this.pushDiagnostic(
+                this.document.uri,
+                new Diagnostic(this.document.lineAt(line - 1).range, message, severity)
+            );
+        } else {
+            this.di.setInjectionError(true);
         }
     }
 
     private provideInput(result: ChildProcess): void {
         const stdinStream = new Stream.Readable();
-        const text = this.di.getText();
+        const text = this.di.getCompilerText();
+        this.compilerTextLineStarts = this.computeLineStarts(text);
         stdinStream.push(text);
         stdinStream.push(null);
         stdinStream.pipe(result.stdin);

--- a/src/providers/glsl-rename-provider.ts
+++ b/src/providers/glsl-rename-provider.ts
@@ -92,7 +92,11 @@ export class GlslRenameProvider extends PositionalProviderBase<Range> implements
 
     private rename(we: WorkspaceEdit, interval: Interval): void {
         if (interval && !interval.isInjected()) {
-            we.replace(this.document.uri, this.di.intervalToRange(interval), this.newName);
+            const loc = this.di.intervalToLocation(interval);
+            if (!loc) {
+                return;
+            }
+            we.replace(loc.uri, loc.range, this.newName);
         }
     }
 

--- a/src/scope/interval.ts
+++ b/src/scope/interval.ts
@@ -3,10 +3,18 @@ import { DocumentInfo } from '../core/document-info';
 export class Interval {
     private readonly _startIndex: number;
     private readonly _stopIndex: number;
+    private readonly _injected: boolean;
 
     public constructor(startIndex: number, stopIndex: number, di: DocumentInfo) {
-        this._startIndex = startIndex - di.getInjectionOffset();
-        this._stopIndex = stopIndex - di.getInjectionOffset();
+        if (di.hasSourceMap()) {
+            this._startIndex = startIndex;
+            this._stopIndex = stopIndex;
+            this._injected = di.isVirtualOffsetInjected(startIndex);
+        } else {
+            this._startIndex = startIndex - di.getInjectionOffset();
+            this._stopIndex = stopIndex - di.getInjectionOffset();
+            this._injected = this._startIndex < 0;
+        }
     }
 
     public get startIndex(): number {
@@ -18,6 +26,6 @@ export class Interval {
     }
 
     public isInjected(): boolean {
-        return this.startIndex < 0;
+        return this._injected;
     }
 }


### PR DESCRIPTION
This PR adds opt-in GLSL `#include` support, implemented as five incremental phases to keep reviewable commits and isolate responsibilities (resolution, expansion, mapping, integration, and UX).

**Phases:**
* phase 1: resolve `#include` directives + configuration surface;
* phase 2: expand includes into a virtual document + build a source map;
* phase 3: feed the virtual text into the existing parse/scope pipeline (and keep navigation stable);
* phase 4: cache/invalidate expansion and support reading unsaved included buffers;
* phase 5: map diagnostics + rename edits back to the correct originating file;

**How it works (under the hood):**
Build an include graph by scanning `#include` lines and resolving paths (quoted relative + configured search paths, optional angled includes). Expand into a single "virtual" text snapshot by inlining included files, while building a SourceMap that maps virtual offsets <-> original (uri, offset). The existing processing pipeline consumes the expanded text when enabled; providers use the mapping layer to translate locations/ranges back to real files. Expansion is cached and invalidated when any participating document changes; includes can be sourced from open (unsaved) editors.

**Main building blocks:**
* resolver / types: `include-resolver.ts`, `include-types.ts`
* expander + mapping: `include-expander.ts`, `source-map.ts`
* cache + unsaved reads: `expanded-document-cache.ts`, `workspace-text.ts`
* integration + providers: `document-info.ts`, `glsl-diagnostic-provider.ts`, `glsl-rename-provider.ts`

**User-facing behavior:**
When **`includes.enabled`** is on, definition/rename/diagnostics work across include boundaries with correct file targeting via the source map.