### PR TITLE
Fix: Support multi-case (fall-through) labels in switch-case statements

### DIFF
--- a/src/core/glsl-visitor.ts
+++ b/src/core/glsl-visitor.ts
@@ -357,18 +357,23 @@ export class GlslVisitor extends AbstractParseTreeVisitor<void> implements Antlr
 
     public visitCase_group(ctx: Case_groupContext): void {
         Helper.addFoldingRegionFromTokens(this.di, ctx.start, ctx.stop, -1);
+
+        const labels = ctx.case_label();
+        const firstLabel = labels[0];
+        const lastLabel = labels[labels.length - 1];
+
         this.di
             .getRegions()
-            .caseHeaderRegions.push(
-                new Interval(ctx.case_label().start.startIndex, ctx.case_label().stop.stopIndex + 1, this.di)
-            );
-        if (ctx.statement()[0].simple_statement()) {
+            .caseHeaderRegions.push(new Interval(firstLabel.start.startIndex, lastLabel.stop.stopIndex + 1, this.di));
+
+        const statements = ctx.statement();
+        if (statements.length > 0 && statements[0].simple_statement()) {
             this.di
                 .getRegions()
                 .caseStatementsRegions.push(
                     new Interval(
-                        ctx.statement()[0].start.startIndex,
-                        ctx.statement()[ctx.statement().length - 1].stop.stopIndex + 1,
+                        statements[0].start.startIndex,
+                        statements[statements.length - 1].stop.stopIndex + 1,
                         this.di
                     )
                 );

--- a/src/core/glsl-visitor.ts
+++ b/src/core/glsl-visitor.ts
@@ -359,23 +359,26 @@ export class GlslVisitor extends AbstractParseTreeVisitor<void> implements Antlr
         Helper.addFoldingRegionFromTokens(this.di, ctx.start, ctx.stop, -1);
 
         const labels = ctx.case_label();
-        const firstLabel = labels[0];
-        const lastLabel = labels[labels.length - 1];
+        if (labels.length > 0) {
+            const firstLabel = labels[0];
+            const lastLabel = labels[labels.length - 1];
 
-        this.di
-            .getRegions()
-            .caseHeaderRegions.push(new Interval(firstLabel.start.startIndex, lastLabel.stop.stopIndex + 1, this.di));
+            this.di
+                .getRegions()
+                .caseHeaderRegions.push(
+                    new Interval(firstLabel.start.startIndex, lastLabel.stop.stopIndex + 1, this.di)
+                );
+        }
 
         const statements = ctx.statement();
         if (statements.length > 0 && statements[0].simple_statement()) {
+            const firstStmt = statements[0];
+            const lastStmt = statements[statements.length - 1];
+
             this.di
                 .getRegions()
                 .caseStatementsRegions.push(
-                    new Interval(
-                        statements[0].start.startIndex,
-                        statements[statements.length - 1].stop.stopIndex + 1,
-                        this.di
-                    )
+                    new Interval(firstStmt.start.startIndex, lastStmt.stop.stopIndex + 1, this.di)
                 );
         }
         this.visitChildren(ctx);

--- a/src/core/glsl-visitor.ts
+++ b/src/core/glsl-visitor.ts
@@ -356,29 +356,25 @@ export class GlslVisitor extends AbstractParseTreeVisitor<void> implements Antlr
     }
 
     public visitCase_group(ctx: Case_groupContext): void {
-        Helper.addFoldingRegionFromTokens(this.di, ctx.start, ctx.stop, -1);
-
         const labels = ctx.case_label();
-        if (labels.length > 0) {
-            const firstLabel = labels[0];
-            const lastLabel = labels[labels.length - 1];
+        const firstLabel = labels[0];
+        const lastLabel = labels[labels.length - 1];
 
-            this.di
-                .getRegions()
-                .caseHeaderRegions.push(
-                    new Interval(firstLabel.start.startIndex, lastLabel.stop.stopIndex + 1, this.di)
-                );
-        }
+        Helper.addFoldingRegionFromTokens(this.di, lastLabel.start, ctx.stop, -1);
+
+        this.di
+            .getRegions()
+            .caseHeaderRegions.push(new Interval(firstLabel.start.startIndex, lastLabel.stop.stopIndex + 1, this.di));
 
         const statements = ctx.statement();
-        if (statements.length > 0 && statements[0].simple_statement()) {
-            const firstStmt = statements[0];
-            const lastStmt = statements[statements.length - 1];
+        if (statements.length > 0) {
+            const firstStatement = statements[0];
+            const lastStatement = statements[statements.length - 1];
 
             this.di
                 .getRegions()
                 .caseStatementsRegions.push(
-                    new Interval(firstStmt.start.startIndex, lastStmt.stop.stopIndex + 1, this.di)
+                    new Interval(firstStatement.start.startIndex, lastStatement.stop.stopIndex + 1, this.di)
                 );
         }
         this.visitChildren(ctx);

--- a/src/providers/glsl-document-formatting-provider.ts
+++ b/src/providers/glsl-document-formatting-provider.ts
@@ -237,7 +237,8 @@ export class GlslDocumentFormattingProvider
                 t2.type !== AntlrGlslLexer.LRB &&
                 (t1.type !== AntlrGlslLexer.KW_ELSE || t2.type !== AntlrGlslLexer.KW_IF)) ||
             (this.ctx.caseStatementsStart &&
-                (t2.type !== AntlrGlslLexer.LCB || GlslEditor.CONFIGURATIONS.getBracesOnSeparateLine()))
+                (t2.type !== AntlrGlslLexer.LCB || GlslEditor.CONFIGURATIONS.getBracesOnSeparateLine())) ||
+            t2.type === AntlrGlslLexer.KW_CASE
         );
     }
 

--- a/syntaxes/AntlrGlslParser.g4
+++ b/syntaxes/AntlrGlslParser.g4
@@ -52,7 +52,7 @@ selection_statement : KW_IF LRB expression RRB statement (KW_ELSE statement)?;
 //switch-case
 switch_statement : KW_SWITCH LRB expression RRB LCB case_group* RCB;
 
-case_group : case_label statement*;
+case_group : case_label+ statement*;
 
 case_label : (KW_DEFAULT | KW_CASE expression) COLON;
 


### PR DESCRIPTION
This PR fixes an issue where the GLSL parser would crash/error out when encountering multiple case labels for a single code block (fall-through).

Example:
```glsl
void main(int x) {
    switch(x) {
        case 1:
        case 2: // This causes the parser to fail
            return;
        default:
            break;
    }
}
```

Updates:
> Updated grammar in `AntlrGlslParser.g4` to allow more labels per group.
> Updated `src/core/glsl-visitor.ts` to handle the resulting array of labels in `visitCase_group` as well as added a safety check to ensure statements exist before accessing them.